### PR TITLE
Added CMU dataset, bugfix DBPedia, and expanded readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ train_data, dev_data = imdb_loader()
 | -------------------- | -------------------------------------------- | ----------------------------------------- | :------: |
 | `imdb`               | IMDB sentiment dataset                       | Binary classification: sentiment analysis |    ✓     |
 | `dbpedia`            | DBPedia ontology dataset                     | Multi-label (exclusive) classification    |    ✓     |
-| `quora_questions`    | Quora question answer dataset                |                                           |    ✓     |
+| `quora_questions`    | Duplicate Quora questions dataset            | Detecting duplicate questions             |    ✓     |
 | `reuters`            | Reuters dataset                              |                                           |    ✓     |
 | `snli`               | Stanford Natural Language Inference corpus   |                                           |    ✓     |
 | `stack_exchange`     | Stack Exchange dataset                       |                                           |          |
@@ -50,10 +50,9 @@ train_data, dev_data = imdb_loader()
 
 #### Other ML datasets
 
-| ID / Function        | Description                                  | ML task                                  | From URL |
-| -------------------- | -------------------------------------------- | ----------------------------------------- | :------: |
-| `mnist`              | MNIST data                                   |  Image recognition                                         |    ✓     |
-
+| ID / Function | Description | ML task           | From URL |
+| ------------- | ----------- | ----------------- | :------: |
+| `mnist`       | MNIST data  | Image recognition |    ✓     |
 
 ### Dataset details
 
@@ -68,12 +67,12 @@ train_data, dev_data = ml_datasets.imdb()
 - Download URL: [http://ai.stanford.edu/~amaas/data/sentiment/](http://ai.stanford.edu/~amaas/data/sentiment/)
 - Citation: [Andrew L. Maas et al., 2011](https://www.aclweb.org/anthology/P11-1015/)
 
-| Property                      | Training         | Dev              |
-| ----------------------------- | ---------------- | ---------------- |
-| # Instances                   | 25000            | 25000            |
-| Label values                  | {`0`, `1`}       | {`0`, `1`}       |
-| Number of labels per instance | 1 (single)       | 1 (single)       |
-| Label distribution            | balanced (50/50) | balanced (50/50) |
+| Property            | Training         | Dev              |
+| ------------------- | ---------------- | ---------------- |
+| # Instances         | 25000            | 25000            |
+| Label values        | {`0`, `1`}       | {`0`, `1`}       |
+| Labels per instance | Single           | Single           |
+| Label distribution  | Balanced (50/50) | Balanced (50/50) |
 
 #### DBPedia
 
@@ -83,15 +82,34 @@ train_data, dev_data = ml_datasets.dbpedia()
 
 Each instance contains an ontological description, and a classification into one of the 14 distinct labels.
 
-- Download URL: [Via fast.ai](https://s3.amazonaws.com/fast-ai-nlp/dbpedia_csv.tgz)
+- Download URL: [Via fast.ai](https://course.fast.ai/datasets)
 - Original citation: [Xiang Zhang et al., 2015](https://arxiv.org/abs/1509.01626)
 
-| Property                      | Training   | Dev        |
-| ----------------------------- | ---------- | ---------- |
-| # Instances                   | 560000     | 70000      |
-| Label values                  | `1`-`14`   | `1`-`14`   |
-| Number of labels per instance | 1 (single) | 1 (single) |
-| Label distribution            | balanced   | balanced   |
+| Property            | Training | Dev      |
+| ------------------- | -------- | -------- |
+| # Instances         | 560000   | 70000    |
+| Label values        | `1`-`14` | `1`-`14` |
+| Labels per instance | Single   | Single   |
+| Label distribution  | Balanced | Balanced |
+
+#### Quora
+
+```python
+train_data, dev_data = ml_datasets.quora_questions()
+```
+
+Each instance contains two quora questions, and a label indicating whether or not they are duplicates (`0`: no, `1`:yes).
+The ground-truth labels contain some amount of noise: they are not guaranteed to be perfect.
+
+- Download URL: [http://qim.fs.quoracdn.net/quora_duplicate_questions.tsv](http://qim.fs.quoracdn.net/quora_duplicate_questions.tsv)
+- Original citation: [Kornél Csernai et al., 2017](https://www.quora.com/q/quoradata/First-Quora-Dataset-Release-Question-Pairs)
+
+| Property            | Training                  | Dev                       |
+| ------------------- | ------------------------- | ------------------------- |
+| # Instances         | 363859                    | 40429                     |
+| Label values        | {`0`, `1`}                | {`0`, `1`}                |
+| Labels per instance | Single                    | Single                    |
+| Label distribution  | Imbalanced: 63% label `0` | Imbalanced: 63% label `0` |
 
 ### Registering loaders
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Each instance contains the text of a movie review, and a sentiment expressed as 
 ```python
 train_data, dev_data = ml_datasets.imdb()
 for text, annot in train_data[0:5]:
-    print(text)
-    print(annot)
+    print(f"Review: {text}")
+    print(f"Sentiment: {annot}")
 ```
 
 - Download URL: [http://ai.stanford.edu/~amaas/data/sentiment/](http://ai.stanford.edu/~amaas/data/sentiment/)
@@ -79,14 +79,14 @@ for text, annot in train_data[0:5]:
 
 #### DBPedia
 
+Each instance contains an ontological description, and a classification into one of the 14 distinct labels.
+
 ```python
 train_data, dev_data = ml_datasets.dbpedia()
 for text, annot in train_data[0:5]:
-    print(text)
-    print(annot)
+    print(f"Text: {text}")
+    print(f"Category: {annot}")
 ```
-
-Each instance contains an ontological description, and a classification into one of the 14 distinct labels.
 
 - Download URL: [Via fast.ai](https://course.fast.ai/datasets)
 - Original citation: [Xiang Zhang et al., 2015](https://arxiv.org/abs/1509.01626)
@@ -98,18 +98,39 @@ Each instance contains an ontological description, and a classification into one
 | Labels per instance | Single   | Single   |
 | Label distribution  | Balanced | Balanced |
 
+#### CMU
+
+Each instance contains a movie description, and a classification into a list of appropriate genres.
+
+```python
+train_data, dev_data = ml_datasets.cmu()
+for text, annot in train_data[0:5]:
+    print(f"Text: {text}")
+    print(f"Genres: {annot}")
+```
+
+- Download URL: [http://www.cs.cmu.edu/~ark/personas/](http://www.cs.cmu.edu/~ark/personas/)
+- Original citation: [David Bamman et al., 2013](https://www.aclweb.org/anthology/P13-1035/)
+
+| Property            | Training                                                                                           | Dev |
+| ------------------- | -------------------------------------------------------------------------------------------------- | --- |
+| # Instances         | 41793                                                                                                   |0   |
+| Label values        | 363 different genres                                                                              | -   |
+| Labels per instance | Multiple                                                                                           | -   |
+| Label distribution  | Imbalanced: 147 labels with less than 20 examples, while `Drama` occurs more than 19000 times | -   |
+
 #### Quora
 
 ```python
 train_data, dev_data = ml_datasets.quora_questions()
 for questions, annot in train_data[0:50]:
     q1, q2 = questions
-    print(q1)
-    print(q2)
-    print(annot)
+    print(f"Question 1: {q1}")
+    print(f"Question 2: {q2}")
+    print(f"Similarity: {annot}")
 ```
 
-Each instance contains two quora questions, and a label indicating whether or not they are duplicates (`0`: no, `1`:yes).
+Each instance contains two quora questions, and a label indicating whether or not they are duplicates (`0`: no, `1`: yes).
 The ground-truth labels contain some amount of noise: they are not guaranteed to be perfect.
 
 - Download URL: [http://qim.fs.quoracdn.net/quora_duplicate_questions.tsv](http://qim.fs.quoracdn.net/quora_duplicate_questions.tsv)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ train_data, dev_data = imdb_loader()
 | ID / Function        | Description                                  | NLP task                                  | From URL |
 | -------------------- | -------------------------------------------- | ----------------------------------------- | :------: |
 | `imdb`               | IMDB sentiment dataset                       | Binary classification: sentiment analysis |    ✓     |
-| `dbpedia`            | DBPedia ontology dataset                     | Multi-label (exclusive) classification    |    ✓     |
+| `dbpedia`            | DBPedia ontology dataset                     | Multi-class single-label classification   |    ✓     |
+| `cmu`                | CMU movie genres dataset                     | Multi-class, multi-label classification   |    ✓     |
 | `quora_questions`    | Duplicate Quora questions dataset            | Detecting duplicate questions             |    ✓     |
 | `reuters`            | Reuters dataset (texts not included)         | Multi-class multi-label classification    |    ✓     |
 | `snli`               | Stanford Natural Language Inference corpus   | Recognizing textual entailment            |    ✓     |
@@ -112,11 +113,11 @@ for text, annot in train_data[0:5]:
 - Download URL: [http://www.cs.cmu.edu/~ark/personas/](http://www.cs.cmu.edu/~ark/personas/)
 - Original citation: [David Bamman et al., 2013](https://www.aclweb.org/anthology/P13-1035/)
 
-| Property            | Training                                                                                           | Dev |
-| ------------------- | -------------------------------------------------------------------------------------------------- | --- |
-| # Instances         | 41793                                                                                                   |0   |
-| Label values        | 363 different genres                                                                              | -   |
-| Labels per instance | Multiple                                                                                           | -   |
+| Property            | Training                                                                                      | Dev |
+| ------------------- | --------------------------------------------------------------------------------------------- | --- |
+| # Instances         | 41793                                                                                         | 0   |
+| Label values        | 363 different genres                                                                          | -   |
+| Labels per instance | Multiple                                                                                      | -   |
 | Label distribution  | Imbalanced: 147 labels with less than 20 examples, while `Drama` occurs more than 19000 times | -   |
 
 #### Quora

--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ train_data, dev_data = imdb_loader()
 | `imdb`               | IMDB sentiment dataset                       | Binary classification: sentiment analysis |    ✓     |
 | `dbpedia`            | DBPedia ontology dataset                     | Multi-label (exclusive) classification    |    ✓     |
 | `quora_questions`    | Duplicate Quora questions dataset            | Detecting duplicate questions             |    ✓     |
-| `reuters`            | Reuters dataset                              |                                           |    ✓     |
-| `snli`               | Stanford Natural Language Inference corpus   |                                           |    ✓     |
-| `stack_exchange`     | Stack Exchange dataset                       |                                           |          |
+| `reuters`            | Reuters dataset (texts not included)         | Multi-class multi-label classification    |    ✓     |
+| `snli`               | Stanford Natural Language Inference corpus   | Recognizing textual entailment            |    ✓     |
+| `stack_exchange`     | Stack Exchange dataset                       | Question Answering                        |          |
 | `ud_ancora_pos_tags` | Universal Dependencies Spanish AnCora corpus | POS tagging                               |    ✓     |
 | `ud_ewtb_pos_tags`   | Universal Dependencies English EWT corpus    | POS tagging                               |    ✓     |
-| `wikiner`            | WikiNER data                                 |                                           |          |
+| `wikiner`            | WikiNER data                                 | Named entity recognition                  |          |
 
 #### Other ML datasets
 
@@ -62,6 +62,9 @@ Each instance contains the text of a movie review, and a sentiment expressed as 
 
 ```python
 train_data, dev_data = ml_datasets.imdb()
+for text, annot in train_data[0:5]:
+    print(text)
+    print(annot)
 ```
 
 - Download URL: [http://ai.stanford.edu/~amaas/data/sentiment/](http://ai.stanford.edu/~amaas/data/sentiment/)
@@ -78,6 +81,9 @@ train_data, dev_data = ml_datasets.imdb()
 
 ```python
 train_data, dev_data = ml_datasets.dbpedia()
+for text, annot in train_data[0:5]:
+    print(text)
+    print(annot)
 ```
 
 Each instance contains an ontological description, and a classification into one of the 14 distinct labels.
@@ -96,6 +102,11 @@ Each instance contains an ontological description, and a classification into one
 
 ```python
 train_data, dev_data = ml_datasets.quora_questions()
+for questions, annot in train_data[0:50]:
+    q1, q2 = questions
+    print(q1)
+    print(q2)
+    print(annot)
 ```
 
 Each instance contains two quora questions, and a label indicating whether or not they are duplicates (`0`: no, `1`:yes).

--- a/README.md
+++ b/README.md
@@ -34,18 +34,64 @@ train_data, dev_data = imdb_loader()
 
 ### Available loaders
 
-| ID / Function        | Description                                                              | From URL |
-| -------------------- | ------------------------------------------------------------------------ | :------: |
-| `imdb`               | IMDB sentiment dataset.                                                  |    ✓     |
-| `mnist`              | MNIST data.                                                              |    ✓     |
-| `quora_questions`    | Quora question answer dataset.                                           |    ✓     |
-| `reuters`            | Reuters dataset.                                                         |    ✓     |
-| `snli`               | Stanford Natural Language Inference corpus.                              |    ✓     |
-| `stack_exchange`     | Stack Exchange dataset.                                                  |          |
-| `ud_ancora_pos_tags` | Universal Dependencies Spanish AnCora corpus (POS tagging).              |    ✓     |
-| `ud_ewtb_pos_tags`   | Universal Dependencies English EWT corpus (POS tagging).                 |    ✓     |
-| `wikiner`            | WikiNER data.                                                            |          |
-| `dbpedia`            | DBPedia ontology dataset via [fast.ai](https://course.fast.ai/datasets). |    ✓     |
+#### NLP datasets
+
+| ID / Function        | Description                                  | NLP task                                  | From URL |
+| -------------------- | -------------------------------------------- | ----------------------------------------- | :------: |
+| `imdb`               | IMDB sentiment dataset                       | Binary classification: sentiment analysis |    ✓     |
+| `dbpedia`            | DBPedia ontology dataset                     | Multi-label (exclusive) classification    |    ✓     |
+| `quora_questions`    | Quora question answer dataset                |                                           |    ✓     |
+| `reuters`            | Reuters dataset                              |                                           |    ✓     |
+| `snli`               | Stanford Natural Language Inference corpus   |                                           |    ✓     |
+| `stack_exchange`     | Stack Exchange dataset                       |                                           |          |
+| `ud_ancora_pos_tags` | Universal Dependencies Spanish AnCora corpus | POS tagging                               |    ✓     |
+| `ud_ewtb_pos_tags`   | Universal Dependencies English EWT corpus    | POS tagging                               |    ✓     |
+| `wikiner`            | WikiNER data                                 |                                           |          |
+
+#### Other ML datasets
+
+| ID / Function        | Description                                  | ML task                                  | From URL |
+| -------------------- | -------------------------------------------- | ----------------------------------------- | :------: |
+| `mnist`              | MNIST data                                   |  Image recognition                                         |    ✓     |
+
+
+### Dataset details
+
+#### IMDB
+
+Each instance contains the text of a movie review, and a sentiment expressed as `0` or `1`.
+
+```python
+train_data, dev_data = ml_datasets.imdb()
+```
+
+- Download URL: [http://ai.stanford.edu/~amaas/data/sentiment/](http://ai.stanford.edu/~amaas/data/sentiment/)
+- Citation: [Andrew L. Maas et al., 2011](https://www.aclweb.org/anthology/P11-1015/)
+
+| Property                      | Training         | Dev              |
+| ----------------------------- | ---------------- | ---------------- |
+| # Instances                   | 25000            | 25000            |
+| Label values                  | {`0`, `1`}       | {`0`, `1`}       |
+| Number of labels per instance | 1 (single)       | 1 (single)       |
+| Label distribution            | balanced (50/50) | balanced (50/50) |
+
+#### DBPedia
+
+```python
+train_data, dev_data = ml_datasets.dbpedia()
+```
+
+Each instance contains an ontological description, and a classification into one of the 14 distinct labels.
+
+- Download URL: [Via fast.ai](https://s3.amazonaws.com/fast-ai-nlp/dbpedia_csv.tgz)
+- Original citation: [Xiang Zhang et al., 2015](https://arxiv.org/abs/1509.01626)
+
+| Property                      | Training   | Dev        |
+| ----------------------------- | ---------- | ---------- |
+| # Instances                   | 560000     | 70000      |
+| Label values                  | `1`-`14`   | `1`-`14`   |
+| Number of labels per instance | 1 (single) | 1 (single) |
+| Label distribution            | balanced   | balanced   |
 
 ### Registering loaders
 

--- a/ml_datasets/__init__.py
+++ b/ml_datasets/__init__.py
@@ -7,3 +7,4 @@ from .snli import snli
 from .stack_exchange import stack_exchange
 from .universal_dependencies import ud_ancora_pos_tags, ud_ewtb_pos_tags
 from .dbpedia import dbpedia
+from .cmu import cmu

--- a/ml_datasets/cmu.py
+++ b/ml_datasets/cmu.py
@@ -1,0 +1,49 @@
+import json
+from pathlib import Path
+import random
+import csv
+
+from .util import get_file
+from ._registry import register_loader
+
+CMU_URL = "http://www.cs.cmu.edu/~ark/personas/data/MovieSummaries.tar.gz"
+
+
+@register_loader("cmu")
+def cmu(loc=None, limit=0):
+    if loc is None:
+        loc = get_file("MovieSummaries", CMU_URL, untar=True, unzip=True)
+    meta_loc = Path(loc) / "movie.metadata.tsv"
+    text_loc = Path(loc) / "plot_summaries.txt"
+    return read_cmu(meta_loc, text_loc, limit=limit), []
+
+
+def read_cmu(meta_loc, text_loc, limit=0, shuffle=True):
+    examples = []
+    genre_by_id = {}
+    title_by_id = {}
+    with meta_loc.open("r", encoding="utf8") as file_:
+        for row in csv.reader(file_, delimiter="\t"):
+            movie_id = row[0]
+            title = row[2]
+            annot = row[8]
+            d = json.loads(annot)
+            genres = set(d.values())
+            genre_by_id[movie_id] = genres
+            title_by_id[movie_id] = title
+
+    with text_loc.open("r", encoding="utf8") as file_:
+        for row in csv.reader(file_, delimiter="\t"):
+            movie_id = row[0]
+            text = row[1]
+            genres = genre_by_id.get(movie_id, None)
+            title = title_by_id.get(movie_id, "")
+            if genres:
+                examples.append((title + "\n" + text, genres))
+
+    if shuffle:
+        random.shuffle(examples)
+    if limit >= 1:
+        examples = examples[:limit]
+
+    return examples

--- a/ml_datasets/dbpedia.py
+++ b/ml_datasets/dbpedia.py
@@ -24,7 +24,7 @@ def dbpedia(loc=None, limit=0, shuffle=True):
 
 def read_dbpedia_ontology(data_file, limit=0, shuffle=True):
     examples = []
-    with open(data_file, newline="") as f:
+    with open(data_file, newline="", encoding='utf-8') as f:
         reader = csv.reader(f)
         for row in reader:
             label = row[0]


### PR DESCRIPTION
- Added CMU: a dataset with movie descriptions + multi-label classification into genres
- Added the specific NLP/ML task to the overview table (+ distinction between NLP & ML)
- Added more data properties for the textcat classification datasets: imdb, dbpedia, cmu and quora_questions
- bugfix for reading dbpedia (ensure UTF8 encoding)