### PR TITLE
MNIST variants

### DIFF
--- a/ml_datasets/loaders/cifar.py
+++ b/ml_datasets/loaders/cifar.py
@@ -61,7 +61,6 @@ def load_cifar10(path='cifar-10-python.tar.gz'):
     return train_images, train_labels, test_images, test_labels
 
 
-# TODO finish this function
 def load_cifar100(path='cifar-100-python.tar.gz', coarse=False):
     path = get_file(path, origin=CIFAR10_URL)
     with tarfile.open(path) as cifarf:

--- a/ml_datasets/loaders/cifar.py
+++ b/ml_datasets/loaders/cifar.py
@@ -1,0 +1,82 @@
+import pickle
+import tarfile
+import random
+import numpy
+
+from ..util import get_file, unzip, to_categorical
+
+CIFAR10_URL = "https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz"
+CIFAR100_URL = "https://www.cs.toronto.edu/~kriz/cifar-100-python.tar.gz"
+
+
+def cifar(variant='10', channels_last=False, shuffle=False):
+    if variant == '10':
+        data = load_cifar10()
+    elif variant == '100':
+        data = load_cifar100()
+    elif variant == '100-coarse':
+        data = load_cifar100(coarse=True)
+    else:
+        raise ValueError("variant must be one of: '10', '100', 100-coarse")
+    X_train, y_train, X_test, y_test = data
+    X_train = X_train.astype("float32")
+    X_test = X_test.astype("float32")
+    X_train /= 255.0
+    X_test /= 255.0
+    if shuffle:
+        train_data = list(zip(X_train, y_train))
+        random.shuffle(train_data)
+        X_train, y_train = unzip(train_data)
+    if channels_last:
+        X_train = X_train.reshape(X_train.shape[0], 32, 32, 3)
+        X_test = X_test.reshape(X_test.shape[0], 32, 32, 3)
+    else:
+        X_train = X_train.reshape(X_train.shape[0], 3, 32, 32)
+        X_test = X_test.reshape(X_test.shape[0], 3, 32, 32)
+    y_train = to_categorical(y_train)
+    y_test = to_categorical(y_test)
+    return (X_train, y_train), (X_test, y_test)
+
+
+def load_cifar10(path='cifar-10-python.tar.gz'):
+    path = get_file(path, origin=CIFAR10_URL)
+    train_images = []
+    train_labels = []
+    with tarfile.open(path) as cifarf:
+        for name in cifarf.getnames():
+            # data is stored in batches
+            if 'data_batch' in name:
+                decompressed = cifarf.extractfile(name)
+                data = pickle.load(decompressed, encoding='bytes')
+                train_images.append(data[b'data'])
+                train_labels += data[b'labels']
+            elif 'test_batch' in name:
+                decompressed = cifarf.extractfile(name)
+                data = pickle.load(decompressed, encoding='bytes')
+                test_images = data[b'data']
+                test_labels = data[b'labels']
+    train_images = numpy.vstack(train_images)
+    train_labels = numpy.asarray(train_labels)
+    test_labels = numpy.asarray(train_labels)
+    return train_images, train_labels, test_images, test_labels
+
+
+# TODO finish this function
+def load_cifar100(path='cifar-100-python.tar.gz', coarse=False):
+    path = get_file(path, origin=CIFAR10_URL)
+    with tarfile.open(path) as cifarf:
+        train_decomp = cifarf.extractfile('cifar-100-python/train')
+        test_decomp = cifarf.extractfile('cifar-100-python/test')
+        train_data = pickle.load(train_decomp, encoding='bytes')
+        test_data = pickle.load(test_decomp, encoding='bytes')
+    train_images = train_data[b'data']
+    test_images = test_data[b'data']
+    if coarse:
+        train_labels = train_data[b'coarse_labels']
+        test_labels = test_data[b'coarse_labels']
+    else:
+        train_labels = train_data[b'fine_labels']
+        test_labels = test_data[b'fine_labels']
+    train_labels = numpy.asarray(train_labels)
+    test_labels = numpy.asarray(test_labels)
+    return train_images, train_labels, test_images, test_labels

--- a/ml_datasets/loaders/cifar.py
+++ b/ml_datasets/loaders/cifar.py
@@ -9,7 +9,7 @@ CIFAR10_URL = "https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz"
 CIFAR100_URL = "https://www.cs.toronto.edu/~kriz/cifar-100-python.tar.gz"
 
 
-def cifar(variant='10', channels_last=False, shuffle=False):
+def cifar(variant='10', channels_last=False, shuffle=True):
     if variant == '10':
         data = load_cifar10()
     elif variant == '100':

--- a/ml_datasets/loaders/cifar.py
+++ b/ml_datasets/loaders/cifar.py
@@ -13,11 +13,11 @@ def cifar(variant='10', channels_last=False, shuffle=True):
     if variant == '10':
         data = load_cifar10()
     elif variant == '100':
-        data = load_cifar100()
+        data = load_cifar100(coarse=False)
     elif variant == '100-coarse':
         data = load_cifar100(coarse=True)
     else:
-        raise ValueError("variant must be one of: '10', '100', 100-coarse")
+        raise ValueError("Variant must be one of: '10', '100', 100-coarse")
     X_train, y_train, X_test, y_test = data
     X_train = X_train.astype("float32")
     X_test = X_test.astype("float32")
@@ -57,7 +57,7 @@ def load_cifar10(path='cifar-10-python.tar.gz'):
                 test_labels = data[b'labels']
     train_images = numpy.vstack(train_images)
     train_labels = numpy.asarray(train_labels)
-    test_labels = numpy.asarray(train_labels)
+    test_labels = numpy.asarray(test_labels)
     return train_images, train_labels, test_images, test_labels
 
 

--- a/ml_datasets/loaders/mnist.py
+++ b/ml_datasets/loaders/mnist.py
@@ -63,7 +63,7 @@ def load_mnist(path="mnist.pkl.gz"):
 
 
 def load_fashion_mnist(
-    train_img_path="",
+    train_img_path="train-images-idx3-ubyte.gz",
     train_label_path="train-labels-idx1-ubyte.gz",
     test_img_path="t10k-images-idx3-ubyte.gz",
     test_label_path="t10k-labels-idz1-ubyte.gz",
@@ -78,14 +78,14 @@ def load_fashion_mnist(
     with gzip.open(train_img_path, "rb") as trimgpath:
         train_images = np.frombuffer(
             trimgpath.read(), dtype=np.uint8, offset=16
-        ).reshape(len(train_labels), 784)
+        ).reshape(len(train_labels), 28, 28)
     with gzip.open(test_label_path, "rb") as telbpath:
         test_labels = np.frombuffer(telbpath.read(), dtype=np.uint8, offset=8)
     with gzip.open(test_img_path, "rb") as teimgpath:
         test_images = np.frombuffer(
             teimgpath.read(), dtype=np.uint8, offset=16
-        ).reshape(len(test_labels), 784)
-    return train_images, train_labels, test_images, test_labels
+        ).reshape(len(test_labels), 28, 28)
+    return (train_images, train_labels), (test_images, test_labels)
 
 
 def load_kuzushiji_mnist(
@@ -98,8 +98,8 @@ def load_kuzushiji_mnist(
     train_label_path = get_file(train_label_path, origin=KU_TR_LBL_URL)
     test_img_path = get_file(test_img_path, origin=KU_TE_IMG_URL)
     test_label_path = get_file(test_label_path, origin=KU_TE_LBL_URL)
-    train_images = np.load(train_img_path)
-    train_labels = np.load(train_label_path)
-    test_images = np.load(test_img_path)
-    test_labels = np.load(test_label_path)
-    return train_images, train_labels, test_images, test_labels
+    train_images = np.load(train_img_path)['arr_0']
+    train_labels = np.load(train_label_path)['arr_0']
+    test_images = np.load(test_img_path)['arr_0']
+    test_labels = np.load(test_label_path)['arr_0']
+    return (train_images, train_labels), (test_images, test_labels)

--- a/ml_datasets/loaders/mnist.py
+++ b/ml_datasets/loaders/mnist.py
@@ -21,8 +21,7 @@ KU_TE_LBL_URL = "http://codh.rois.ac.jp/kmnist/dataset/kmnist/kmnist-test-labels
 
 
 @register_loader("mnist")
-def mnist(variant='mnist'):
-    # the data, shuffled and split between train and test sets
+def mnist(variant='mnist', shuffle=True):
     if variant == 'mnist':
         (X_train, y_train), (X_test, y_test) = load_mnist()
     elif variant == 'fashion':
@@ -37,20 +36,13 @@ def mnist(variant='mnist'):
     X_test = X_test.astype("float32")
     X_train /= 255.0
     X_test /= 255.0
-    train_data = list(zip(X_train, y_train))
-    nr_train = X_train.shape[0]
-    random.shuffle(train_data)
-    # FIXME heldout data never returned?
-    heldout_data = train_data[: int(nr_train * 0.1)]
-    mnist_train = train_data[len(heldout_data) :]
-    # FIXME why zip and then unzip mnist_dev?
-    mnist_dev = list(zip(X_test, y_test))
-
-    train_X, train_Y = unzip(mnist_train)
-    train_Y = to_categorical(train_Y, n_classes=10)
-    dev_X, dev_Y = unzip(mnist_dev)
-    dev_Y = to_categorical(dev_Y, n_classes=10)
-    return (train_X, train_Y), (dev_X, dev_Y)
+    if shuffle:
+        train_data = list(zip(X_train, y_train))
+        random.shuffle(train_data)
+        X_train, y_train = unzip(train_data)
+    y_train = to_categorical(y_train, n_classes=10)
+    y_test = to_categorical(y_test, n_classes=10)
+    return (X_train, y_train), (X_test, y_test)
 
 
 def load_mnist(path="mnist.pkl.gz"):

--- a/ml_datasets/loaders/mnist.py
+++ b/ml_datasets/loaders/mnist.py
@@ -9,15 +9,15 @@ from .._registry import register_loader
 
 MNIST_URL = "https://s3.amazonaws.com/img-datasets/mnist.pkl.gz"
 
-FA_TR_IMG_URL = "http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/train-images-idx3-ubyte.gz"
-FA_TR_LBL_URL = "http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/train-labels-idx1-ubyte.gz"
-FA_TE_IMG_URL = "http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/t10k-images-idx3-ubyte.gz"
-FA_TE_LBL_URL = "http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/t10k-labels-idx1-ubyte.gz"
+FA_TRAIN_IMG_URL = "http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/train-images-idx3-ubyte.gz"
+FA_TRAIN_LBL_URL = "http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/train-labels-idx1-ubyte.gz"
+FA_TEST_IMG_URL = "http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/t10k-images-idx3-ubyte.gz"
+FA_TEST_LBL_URL = "http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/t10k-labels-idx1-ubyte.gz"
 
-KU_TR_IMG_URL = "http://codh.rois.ac.jp/kmnist/dataset/kmnist/kmnist-train-imgs.npz"
-KU_TR_LBL_URL = "http://codh.rois.ac.jp/kmnist/dataset/kmnist/kmnist-train-labels.npz"
-KU_TE_IMG_URL = "http://codh.rois.ac.jp/kmnist/dataset/kmnist/kmnist-test-imgs.npz"
-KU_TE_LBL_URL = "http://codh.rois.ac.jp/kmnist/dataset/kmnist/kmnist-test-labels.npz"
+KU_TRAIN_IMG_URL = "http://codh.rois.ac.jp/kmnist/dataset/kmnist/kmnist-train-imgs.npz"
+KU_TRAIN_LBL_URL = "http://codh.rois.ac.jp/kmnist/dataset/kmnist/kmnist-train-labels.npz"
+KU_TEST_IMG_URL = "http://codh.rois.ac.jp/kmnist/dataset/kmnist/kmnist-test-imgs.npz"
+KU_TEST_LBL_URL = "http://codh.rois.ac.jp/kmnist/dataset/kmnist/kmnist-test-labels.npz"
 
 
 @register_loader("mnist")
@@ -29,7 +29,7 @@ def mnist(variant='mnist', shuffle=True):
     elif variant == 'kuzushiji':
         (X_train, y_train), (X_test, y_test) = load_kuzushiji_mnist()
     else:
-        raise ValueError("variant must be one of: 'mnist', 'fashion', 'kuzushiji'")
+        raise ValueError("Variant must be one of: 'mnist', 'fashion', 'kuzushiji'")
     X_train = X_train.reshape(60000, 784)
     X_test = X_test.reshape(10000, 784)
     X_train = X_train.astype("float32")
@@ -62,10 +62,10 @@ def load_fashion_mnist(
     test_img_path="t10k-images-idx3-ubyte.gz",
     test_label_path="t10k-labels-idz1-ubyte.gz",
 ):
-    train_img_path = get_file(train_img_path, origin=FA_TR_IMG_URL)
-    train_label_path = get_file(train_label_path, origin=FA_TR_LBL_URL)
-    test_img_path = get_file(test_img_path, origin=FA_TE_IMG_URL)
-    test_label_path = get_file(test_label_path, origin=FA_TE_LBL_URL)
+    train_img_path = get_file(train_img_path, origin=FA_TRAIN_IMG_URL)
+    train_label_path = get_file(train_label_path, origin=FA_TRAIN_LBL_URL)
+    test_img_path = get_file(test_img_path, origin=FA_TEST_IMG_URL)
+    test_label_path = get_file(test_label_path, origin=FA_TEST_LBL_URL)
     # Based on https://github.com/zalandoresearch/fashion-mnist/blob/master/utils/mnist_reader.py
     with gzip.open(train_label_path, "rb") as trlbpath:
         train_labels = np.frombuffer(trlbpath.read(), dtype=np.uint8, offset=8)
@@ -88,10 +88,10 @@ def load_kuzushiji_mnist(
     test_img_path="kmnist-test-imgs.npz",
     test_label_path="kmnist-test-labels.npz",
 ):
-    train_img_path = get_file(train_img_path, origin=KU_TR_IMG_URL)
-    train_label_path = get_file(train_label_path, origin=KU_TR_LBL_URL)
-    test_img_path = get_file(test_img_path, origin=KU_TE_IMG_URL)
-    test_label_path = get_file(test_label_path, origin=KU_TE_LBL_URL)
+    train_img_path = get_file(train_img_path, origin=KU_TRAIN_IMG_URL)
+    train_label_path = get_file(train_label_path, origin=KU_TRAIN_LBL_URL)
+    test_img_path = get_file(test_img_path, origin=KU_TEST_IMG_URL)
+    test_label_path = get_file(test_label_path, origin=KU_TEST_LBL_URL)
     train_images = np.load(train_img_path)['arr_0']
     train_labels = np.load(train_label_path)['arr_0']
     test_images = np.load(test_img_path)['arr_0']

--- a/ml_datasets/loaders/mnist.py
+++ b/ml_datasets/loaders/mnist.py
@@ -1,18 +1,36 @@
 import random
 import gzip
+import numpy as np
 from srsly import cloudpickle as pickle
 
 from ..util import unzip, to_categorical, get_file
 from .._registry import register_loader
 
 
-URL = "https://s3.amazonaws.com/img-datasets/mnist.pkl.gz"
+MNIST_URL = "https://s3.amazonaws.com/img-datasets/mnist.pkl.gz"
+
+FA_TR_IMG_URL = "http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/train-images-idx3-ubyte.gz"
+FA_TR_LBL_URL = "http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/train-labels-idx1-ubyte.gz"
+FA_TE_IMG_URL = "http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/t10k-images-idx3-ubyte.gz"
+FA_TE_LBL_URL = "http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/t10k-labels-idx1-ubyte.gz"
+
+KU_TR_IMG_URL = "http://codh.rois.ac.jp/kmnist/dataset/kmnist/kmnist-train-imgs.npz"
+KU_TR_LBL_URL = "http://codh.rois.ac.jp/kmnist/dataset/kmnist/kmnist-train-labels.npz"
+KU_TE_IMG_URL = "http://codh.rois.ac.jp/kmnist/dataset/kmnist/kmnist-test-imgs.npz"
+KU_TE_LBL_URL = "http://codh.rois.ac.jp/kmnist/dataset/kmnist/kmnist-test-labels.npz"
 
 
 @register_loader("mnist")
-def mnist():
-    # the data, shuffled and split between tran and test sets
-    (X_train, y_train), (X_test, y_test) = load_mnist()
+def mnist(variant='mnist'):
+    # the data, shuffled and split between train and test sets
+    if variant == 'mnist':
+        (X_train, y_train), (X_test, y_test) = load_mnist()
+    elif variant == 'fashion':
+        (X_train, y_train), (X_test, y_test) = load_fashion_mnist()
+    elif variant == 'kuzushiji':
+        (X_train, y_train), (X_test, y_test) = load_kuzushiji_mnist()
+    else:
+        raise ValueError("variant must be one of: 'mnist', 'fashion', 'kuzushiji'")
     X_train = X_train.reshape(60000, 784)
     X_test = X_test.reshape(10000, 784)
     X_train = X_train.astype("float32")
@@ -34,7 +52,7 @@ def mnist():
 
 
 def load_mnist(path="mnist.pkl.gz"):
-    path = get_file(path, origin=URL)
+    path = get_file(path, origin=MNIST_URL)
     if path.endswith(".gz"):
         f = gzip.open(path, "rb")
     else:
@@ -42,3 +60,46 @@ def load_mnist(path="mnist.pkl.gz"):
     data = pickle.load(f, encoding="bytes")
     f.close()
     return data  # (X_train, y_train), (X_test, y_test)
+
+
+def load_fashion_mnist(
+    train_img_path="",
+    train_label_path="train-labels-idx1-ubyte.gz",
+    test_img_path="t10k-images-idx3-ubyte.gz",
+    test_label_path="t10k-labels-idz1-ubyte.gz",
+):
+    train_img_path = get_file(train_img_path, origin=FA_TR_IMG_URL)
+    train_label_path = get_file(train_label_path, origin=FA_TR_LBL_URL)
+    test_img_path = get_file(test_img_path, origin=FA_TE_IMG_URL)
+    test_label_path = get_file(test_label_path, origin=FA_TE_LBL_URL)
+    # Based on https://github.com/zalandoresearch/fashion-mnist/blob/master/utils/mnist_reader.py
+    with gzip.open(train_label_path, "rb") as trlbpath:
+        train_labels = np.frombuffer(trlbpath.read(), dtype=np.uint8, offset=8)
+    with gzip.open(train_img_path, "rb") as trimgpath:
+        train_images = np.frombuffer(
+            trimgpath.read(), dtype=np.uint8, offset=16
+        ).reshape(len(train_labels), 784)
+    with gzip.open(test_label_path, "rb") as telbpath:
+        test_labels = np.frombuffer(telbpath.read(), dtype=np.uint8, offset=8)
+    with gzip.open(test_img_path, "rb") as teimgpath:
+        test_images = np.frombuffer(
+            teimgpath.read(), dtype=np.uint8, offset=16
+        ).reshape(len(test_labels), 784)
+    return train_images, train_labels, test_images, test_labels
+
+
+def load_kuzushiji_mnist(
+    train_img_path="kmnist-train-imgs.npz",
+    train_label_path="kmnist-train-labels.npz",
+    test_img_path="kmnist-test-imgs.npz",
+    test_label_path="kmnist-test-labels.npz",
+):
+    train_img_path = get_file(train_img_path, origin=KU_TR_IMG_URL)
+    train_label_path = get_file(train_label_path, origin=KU_TR_LBL_URL)
+    test_img_path = get_file(test_img_path, origin=KU_TE_IMG_URL)
+    test_label_path = get_file(test_label_path, origin=KU_TE_LBL_URL)
+    train_images = np.load(train_img_path)
+    train_labels = np.load(train_label_path)
+    test_images = np.load(test_img_path)
+    test_labels = np.load(test_label_path)
+    return train_images, train_labels, test_images, test_labels

--- a/ml_datasets/loaders/mnist.py
+++ b/ml_datasets/loaders/mnist.py
@@ -40,8 +40,10 @@ def mnist(variant='mnist'):
     train_data = list(zip(X_train, y_train))
     nr_train = X_train.shape[0]
     random.shuffle(train_data)
+    # FIXME heldout data never returned?
     heldout_data = train_data[: int(nr_train * 0.1)]
     mnist_train = train_data[len(heldout_data) :]
+    # FIXME why zip and then unzip mnist_dev?
     mnist_dev = list(zip(X_test, y_test))
 
     train_X, train_Y = unzip(mnist_train)


### PR DESCRIPTION
This PR adds was supposed to add two new MNIST variants to be able to add more variety when testing some of the core components of a deep learning pipeline such as learning rate schedulers or activation functions. I extended it to add CIFAR too, because it was straightforward to bunch it up with this PR.

The datasets added are:

1. Kuzushiji-MNIST: https://github.com/rois-codh/kmnist
2. Fashion-MNIST: https://github.com/zalandoresearch/fashion-mnist
3. CIFAR-10, CIFAR-100: https://www.cs.toronto.edu/~kriz/cifar.html

Both the MNIST variants have the same high-level characteristics as the original MNIST with `70,000`  `28x28` grayscale images spanning `10 classes`. 

The CIFAR data sets are a bit different: they are 32 x 32 color images so each instance has shape (32, 32, 3). CIFAR-10 has only 10 classes, whereas CIFAR-100 can has 20 coarse grained labels or 100 fine grained labels. The loader allows access to both.