### PR TITLE
Don't obfuscate URLError

### DIFF
--- a/ml_datasets/test/test_util.py
+++ b/ml_datasets/test/test_util.py
@@ -4,7 +4,9 @@ from ml_datasets.util import get_file
 
 
 def test_get_file_domain_resolution_fails():
-    with pytest.raises(URLError, match="test_non_existent_file.*Name or service not known"):
+    with pytest.raises(
+        URLError, match=r"test_non_existent_file.*(not known|getaddrinfo failed)"
+    ):
         get_file(
             "non_existent_file.txt",
             "http://test_notexist.wth/test_non_existent_file.txt"

--- a/ml_datasets/test/test_util.py
+++ b/ml_datasets/test/test_util.py
@@ -1,0 +1,25 @@
+import pytest
+from urllib.error import HTTPError, URLError
+from ml_datasets.util import get_file
+
+
+def test_get_file_domain_resolution_fails():
+    with pytest.raises(URLError, match="test_non_existent_file.*Name or service not known"):
+        get_file(
+            "non_existent_file.txt",
+            "http://test_notexist.wth/test_non_existent_file.txt"
+        )
+
+
+def test_get_file_404_file_not_found():
+    with pytest.raises(HTTPError, match="test_non_existent_file.*404.*Not Found") as e:
+        get_file(
+            "non_existent_file.txt",
+            "http://google.com/test_non_existent_file.txt"
+        )
+    assert e.value.code == 404
+    # Suppress pytest.PytestUnraisableExceptionWarning:
+    #          Exception ignored while calling deallocator
+    # This questionable design quirk comes from urllib.request.urlretrieve,
+    # so we shouldn't shim around it.
+    e.value.close()


### PR DESCRIPTION
- Allow downstream code to selectively catch `URLError` when a download fails.
Notably, this enables downstream tests to use
```python
@pytest.mark.xfail(raises=URLError, reason="download from the internet may fail", strict=False)
def test1():
    dataset = ml_datasets.<some function>()
    ...
```
which will allow for flakiness only in case of download failure, and trigger a test failure otherwise.

- Fix bug where HTTPError would be treated as a generic URLError.